### PR TITLE
Fix Controller getToggle method for IE

### DIFF
--- a/src/toggle/Controller.js
+++ b/src/toggle/Controller.js
@@ -81,7 +81,7 @@ class Controller {
      * @param {String} element
      */
     _getToggle(element) {
-        return this._toggles.find(toggle => toggle.id === element);
+        return this._toggles.filter(toggle => toggle.id === element)[0];
     }
 
     /**


### PR DESCRIPTION
**Reason:** `getToggle()` Controller method breaks in IE<=11 due to the `find()` method not being supported.

Fixed by replacing with the `filter()` method that provides better backwards [compatibility](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter) (IE9 & above) with minimal impact on performance.

